### PR TITLE
Allow passing unlimited args to ^entry

### DIFF
--- a/repldex/discordbot/commands.py
+++ b/repldex/discordbot/commands.py
@@ -119,7 +119,7 @@ async def link_source(message):
 
 
 @betterbot.command(name='entry', allowed=True)
-async def show_entry(message, search_query: str):
+async def show_entry(message, *, search_query: str):
 	if message.message.author.id in BLACKLIST_IDS:
 		await asyncio.sleep(blacklist_wait)
 	found = await database.search_entries(search_query, limit=1)


### PR DESCRIPTION
Closes #82 (I hope) by catching all arguments and joining them into `search_query`.