### PR TITLE
Remove useless dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,17 +6,16 @@ authors = ["mat <replit@matdoes.dev>","prussia","coderman51","minx"]
 
 [tool.poetry.dependencies]
 python = "^3.8"
-discord = "^1.0.1"
 jellyfish = "^0.8.2"
 jinja2 = "^2.11.2"
 motor = "^2.1.0"
 timeago = "^1.0.14"
 aiohttp = "^3.6.2"
-bs4 = "^0.0.1"
 dnspython = "^2.0.0"
 ibm-watson = "4.6.0"
 ibm_cloud_sdk_core = "1.5.1"
-python-dotenv = "^0.15.0"
+beautifulsoup4 = "^4.9.3"
+"discord.py" = "^1.6.0"
 
 [tool.poetry.dev-dependencies]
 pytest = "^6.1.1"


### PR DESCRIPTION
Moved python-dotenv to dev-dependencies and replaced discord and bs4 with discord.py and beautifulsoup4, since discord and bs4 are just mirror packages